### PR TITLE
Add Instagram scraping script using Playwright

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # Playwright
+
+This repository provides a Playwright script for scraping Instagram posts.
+
+## Usage
+
+1. Install dependencies (requires internet access):
+   ```bash
+   pip install -r requirements.txt
+   playwright install
+   ```
+2. Set the `SESSIONID` environment variable with a valid Instagram session cookie:
+   ```bash
+   export SESSIONID="<your_session_cookie>"
+   ```
+3. Run the scraper:
+   ```bash
+   python main.py
+   ```
+
+The script prints a JSON array containing the top five posts from `@brooklyn_apartmentrentals`
+that mention "studio" or "1 bedroom", ranked by likes, comments, and views.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,120 @@
+import os
+import json
+import re
+import asyncio
+from typing import List, Dict
+
+from playwright.async_api import async_playwright
+
+
+BOROUGHS = ["Queens", "Brooklyn", "Bronx", "Manhattan", "Staten Island"]
+
+
+async def scrape_profile(username: str, max_posts: int = 20) -> List[Dict]:
+    """Return raw post data for a given Instagram username."""
+    session_id = os.environ.get("SESSIONID")
+    if not session_id:
+        raise EnvironmentError("SESSIONID environment variable required")
+
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=True)
+        context = await browser.new_context()
+        await context.add_cookies([
+            {
+                "name": "sessionid",
+                "value": session_id,
+                "domain": ".instagram.com",
+                "path": "/",
+                "httpOnly": True,
+                "secure": True,
+            }
+        ])
+        page = await context.new_page()
+        await page.goto(f"https://www.instagram.com/{username}/")
+        # ensure page loaded by waiting for network idle
+        await page.wait_for_load_state("networkidle")
+
+        # Fetch profile data via Instagram web API using the page context
+        profile_json = await page.evaluate(
+            """async (username) => {
+                const res = await fetch(`/api/v1/users/web_profile_info/?username=${username}`);
+                return await res.json();
+            }""",
+            username,
+        )
+        user_id = profile_json.get("data", {}).get("user", {}).get("id")
+        if not user_id:
+            raise RuntimeError("Unable to retrieve user id")
+
+        feed_json = await page.evaluate(
+            """async (uid, count) => {
+                const res = await fetch(`/api/v1/feed/user/${uid}/?count=${count}`);
+                return await res.json();
+            }""",
+            user_id,
+            max_posts,
+        )
+
+        items = feed_json.get("items", [])[:max_posts]
+
+        posts = []
+        for item in items:
+            shortcode = item.get("code") or item.get("pk")
+            reel_url = f"https://www.instagram.com/reel/{shortcode}/" if shortcode else ""
+            caption_text = (
+                item.get("caption", {}).get("text") if item.get("caption") else ""
+            )
+            likes = item.get("like_count", 0)
+            views = item.get("view_count") or item.get("play_count") or 0
+            comments = item.get("comment_count", 0)
+
+            location = ""
+            for borough in BOROUGHS:
+                if re.search(rf"\b{borough}\b", caption_text, re.IGNORECASE):
+                    location = borough
+                    break
+
+            apartment_type = ""
+            if re.search(r"studio", caption_text, re.IGNORECASE):
+                apartment_type = "studio"
+            elif re.search(r"1\s*bed(room)?", caption_text, re.IGNORECASE):
+                apartment_type = "1 bedroom"
+
+            posts.append(
+                {
+                    "reel_url": reel_url,
+                    "likes": likes,
+                    "views": views,
+                    "comments": comments,
+                    "caption_text": caption_text,
+                    "location": location,
+                    "apartment_type": apartment_type,
+                }
+            )
+
+        return posts
+
+
+def rank_posts(posts: List[Dict]) -> List[Dict]:
+    """Rank filtered posts by engagement score."""
+    filtered = [p for p in posts if p.get("apartment_type")]
+
+    def score(p: Dict) -> float:
+        return p.get("likes", 0) + p.get("comments", 0) + p.get("views", 0) / 100.0
+
+    filtered.sort(key=score, reverse=True)
+    top = filtered[:5]
+    for idx, post in enumerate(top, 1):
+        post["rank"] = idx
+    return top
+
+
+async def main() -> None:
+    username = "brooklyn_apartmentrentals"
+    posts = await scrape_profile(username)
+    ranked = rank_posts(posts)
+    print(json.dumps(ranked, indent=2))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+playwright


### PR DESCRIPTION
## Summary
- Add `main.py` to scrape Instagram posts using Playwright and rank top listings
- Document usage and environment requirements
- Declare dependency on Playwright in `requirements.txt`

## Testing
- `python -m py_compile main.py`
- `SESSIONID=dummy python main.py` *(fails: ModuleNotFoundError: No module named 'playwright')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement playwright (from versions: none))*

------
https://chatgpt.com/codex/tasks/task_e_68942a4f7fc08321b4720443b40ede42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an Instagram scraping tool that fetches recent posts from a specified profile and outputs a JSON list of the top five listings.
  - Filters for “studio” and “1 bedroom” mentions, detects NYC boroughs, and ranks posts by engagement.

- Documentation
  - Expanded README with setup steps, environment variable configuration, run command, and details on output.

- Chores
  - Added Playwright as a new dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->